### PR TITLE
github repository name can contain dots

### DIFF
--- a/app/config.php.dist
+++ b/app/config.php.dist
@@ -24,7 +24,7 @@ $app['composer.repository.url_default'] = 'git@github.com:MyLittleParis/';
 /**
  * Default repository url pattern
  */
-$app['repository.pattern'] = 'https://github.com/[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+(.git)?|git@github.com:[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+.git';
+$app['repository.pattern'] = 'https://github.com/[a-zA-Z0-9-_]+/[a-zA-Z0-9-_\.]+(.git)?|git@github.com:[a-zA-Z0-9-_]+/[a-zA-Z0-9-_\.]+.git';
 
 /**
  * More restrictive username/email constraints for production


### PR DESCRIPTION
This PR fixes the pattern in config.php sample
