### PR TITLE
Add option to format satis file configuration

### DIFF
--- a/app/config.php.dist
+++ b/app/config.php.dist
@@ -6,6 +6,13 @@
 $app['satis.filename'] = __DIR__.'/../satis.json';
 
 /**
+ * Satis file formating options
+ *
+ * See http://php.net/manual/en/json.constants.php for constants description
+ */
+$app['satis.file_formatting'] = JSON_PRETTY_PRINT;
+
+/**
  * Satis auditlog (cheap backup/versioning) path
  */
 $app['satis.auditlog'] = __DIR__.'/data';

--- a/src/Playbloom/Satisfy/Provider/SatisServiceProvider.php
+++ b/src/Playbloom/Satisfy/Provider/SatisServiceProvider.php
@@ -29,12 +29,16 @@ class SatisServiceProvider implements ServiceProviderInterface
             $filesystem = new Filesystem();
 
             $serializer = SerializerBuilder::create()
-                ->configureHandlers(function(HandlerRegistry $registry) {
+                ->configureHandlers(function(HandlerRegistry $registry) use ($app) {
                     $registry->registerHandler('serialization', 'RepositoryCollection', 'json',
-                        function($visitor, Map $map, array $type, Context $context) {
+                        function($visitor, Map $map, array $type, Context $context) use ($app) {
                             // We change the base type, and pass through possible parameters.
                             $type['name'] = 'array';
                             $data = $map->values();
+
+                            if (!empty($app['satis.file_formatting'])) {
+                                $visitor->setOptions(JSON_PRETTY_PRINT);
+                            }
 
                             return $visitor->visitArray($data, $type, $context);
                         }


### PR DESCRIPTION
This PR add an option to Satisfy configuration to allow satis file configuration formatting.

Because sometimes, the file need to be human readable :)