### PR TITLE
Templated the unavailable page, removed some inline HTML in the process

### DIFF
--- a/app/satisfy.php
+++ b/app/satisfy.php
@@ -3,28 +3,20 @@
 $app = require_once __DIR__ . '/bootstrap.php';
 
 /**
- * Homepage, shows satis index.html file if available
- * and adds a link to satisfy backend.
- * @var \Silex\Application $app
+ * Displays the Satis index, returns the unavailable page
+ * when the Satis index.html isn't available.
+ *
+ * @param  \Silex\Application  $app
+ * @return Symfony\Component\HttpFoundation\BinaryFileResponse|Symfony\Component\HttpFoundation\Response
  */
 $app->get('/', function () use ($app) {
     $indexPath = __DIR__ . '/../web/index.html';
-    if (file_exists($indexPath)) {
-        return $app->sendFile($indexPath);
+
+    if (! file_exists($indexPath)) {
+        return $app['twig']->render('unavailable.html.twig');
     }
 
-    return <<<HTML404
-<html>
-    <head>
-        <title>Composer Repository currently not available</title>
-    </head>
-    <body>
-        <h1>Composer Repository currently not available.</h1>
-        <p><a href="/admin/">Manage Repositories</a></p>
-    </body>
-</html>
-HTML404;
-
+    return $app->sendFile($indexPath);
 })->bind('home');
 
 $app->mount('/admin/', new \Playbloom\Satisfy\Controller\SecurityController());

--- a/src/Playbloom/Satisfy/Resources/views/unavailable.html.twig
+++ b/src/Playbloom/Satisfy/Resources/views/unavailable.html.twig
@@ -1,0 +1,13 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Composer Repository currently not available{% endblock %}
+
+{% block header %}
+    Composer Repository currently not available
+{% endblock %}
+
+{% block content %}
+    <a href="{{ path('repository') }}" class="btn btn-large btn-block btn-primary">
+        Manage Repositories
+    </a>
+{% endblock %}


### PR DESCRIPTION
Just some cleaning up.
This removes the inline HTML in `satisfy.php`, displayed when the Satis index.html isn't available. 

![screen shot 2016-02-06 at 00 12 10](https://cloud.githubusercontent.com/assets/2406615/12861849/9406c620-cc66-11e5-8292-9686c195e93a.png)
