### PR TITLE
Fixed repository type being set to the select index

### DIFF
--- a/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
+++ b/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
@@ -25,7 +25,10 @@ class RepositoryType extends AbstractType
                 'type',
                 'choice',
                 array(
-                    'choices' => array('git', 'vcs'),
+                    'choices' => array(
+                        'git' => 'git',
+                        'vcs' => 'vcs',
+                    ),
                     'constraints' => array(
                         new Assert\NotBlank(),
                         new Assert\Choice(array('choices' => array('git', 'vcs')))


### PR DESCRIPTION
By not supplying the array as key value pair the repository type would be set to 0 or 1.

This was introduced in #52 