### PR TITLE
Fix cron job overlap

### DIFF
--- a/bin/cron-rebuild.sh
+++ b/bin/cron-rebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+/usr/local/bin/php /var/www/satisfy/bin/console satisfy:rebuild --skip-errors /var/www/satisfy/satis.json /var/www/html > /tmp/satis.log
+

--- a/docker/conf/cron.conf
+++ b/docker/conf/cron.conf
@@ -1,2 +1,1 @@
-* * * * * www-data /usr/local/bin/php /var/www/satisfy/bin/console satisfy:rebuild -q --skip-errors -l 3600 /var/www/satisfy/satis.json /var/www/html > /tmp/satis.log
-
+* * * * * www-data flock -w 0 /tmp/satisfy.cron.lock /var/www/satisfy/bin/cron-rebuild.sh


### PR DESCRIPTION
As it stands now, the Docker image which is used as the execution environment for `satisfy` has a cron job that runs every minute. If the rebuilding process takes more than a minute to execute (which is easy to achieve with a non-trivial number of indexed packages and archiving turned on) then rebuild processes start executing in parallel. This causes the load average of the machine to increase (and eventually to slow down to a crawl). It also causes the logfile to get truncated even though the rebuilding process is not done.

This fix uses [flock(1)](https://linux.die.net/man/1/flock) to ensure that only one rebuild job will be executed by cron at a time. This also fixes the problem of the logfile getting truncated prematurely.