### PR TITLE
Modified the FilePersister to use League Flysystem

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -51,10 +51,6 @@ $app->register(new TranslationServiceProvider(), array(
     'translator.messages' => array(),
 ));
 
-if (! file_exists($app['satis.filename'])) {
-    throw new RuntimeException('The "satis.json" file could not be found. See "app/config.php" for the configured file location.');
-}
-
 $app->register(new SatisServiceProvider(), array(
     'satis.filename' => $app['satis.filename'],
     'satis.auditlog' => $app['satis.auditlog'],

--- a/app/config.php.dist
+++ b/app/config.php.dist
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * Satis filesystem root path
+ */
+$app['satis.rootPath'] = '/app';
+
+/**
  * Satis configuration file
  */
 $app['satis.filename'] = 'satis.json';

--- a/app/config.php.dist
+++ b/app/config.php.dist
@@ -3,7 +3,7 @@
 /**
  * Satis configuration file
  */
-$app['satis.filename'] = __DIR__.'/../satis.json';
+$app['satis.filename'] = 'satis.json';
 
 /**
  * Satis file formating options
@@ -15,7 +15,7 @@ $app['satis.file_formatting'] = JSON_PRETTY_PRINT;
 /**
  * Satis auditlog (cheap backup/versioning) path
  */
-$app['satis.auditlog'] = __DIR__.'/data';
+$app['satis.auditlog'] = 'data';
 
 /**
  * Satis main configuration class

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,12 @@
         "symfony/translation": "~2.7",
         "symfony/security": "~2.7",
         "symfony/security-csrf": "~2.7",
-        "jms/serializer": "~1.1"
+        "jms/serializer": "~1.1",
+        "league/flysystem": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.x"
+        "phpunit/phpunit": "4.8.x",
+        "league/flysystem-memory": "^1.0"
     },
     "autoload": {
         "psr-4": { "Playbloom\\Satisfy\\": "src/Playbloom/Satisfy" }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ea2d90eab4081dea273d28bebb21046f",
-    "content-hash": "7278faf77029ef6acfee171d4978f245",
+    "hash": "18c0b28d9e8639b5159dcfd1051d4937",
+    "content-hash": "c2ca1fcdd89a5c9210ff01456e7e9cff",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1054,6 +1054,89 @@
             "time": "2016-06-02 10:59:52"
         },
         {
+            "name": "league/flysystem",
+            "version": "1.0.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f400aa98912c561ba625ea4065031b7a41e5a155",
+                "reference": "f400aa98912c561ba625ea4065031b7a41e5a155",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "mockery/mockery": "~0.9",
+                "phpspec/phpspec": "^2.2",
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "time": "2017-08-06 17:41:04"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v2.0.3",
             "source": {
@@ -1234,9 +1317,7 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Pimple is a simple Dependency Injection Container for PHP 5.3",
@@ -3123,6 +3204,420 @@
     ],
     "packages-dev": [
         {
+            "name": "aws/aws-sdk-php",
+            "version": "3.32.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "d34a5779803ae7bc3efd3c6cab6e4e6f3b7409dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/d34a5779803ae7bc3efd3c6cab6e4e6f3b7409dd",
+                "reference": "d34a5779803ae7bc3efd3c6cab6e4e6f3b7409dd",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "^1.4.1",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "^4.8.35|^5.4.0",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "time": "2017-08-01 21:51:56"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2017-06-22 18:50:49"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20 10:07:11"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20 17:10:46"
+        },
+        {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "1.0.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "dc09b19f455750663b922ed52dcc0ff215bed284"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/dc09b19f455750663b922ed52dcc0ff215bed284",
+                "reference": "dc09b19f455750663b922ed52dcc0ff215bed284",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.0.0",
+                "league/flysystem": "^1.0.40",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3v3\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Flysystem adapter for the AWS S3 SDK v3.x",
+            "time": "2017-06-30 06:29:25"
+        },
+        {
+            "name": "league/flysystem-memory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-memory.git",
+                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
+                "reference": "1cabecd08a8caec92a96a953c0d93b5ce83b07a2",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Memory\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Leppanen",
+                    "email": "chris.leppanen@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "An in-memory adapter for Flysystem.",
+            "homepage": "https://github.com/thephpleague/flysystem-memory",
+            "keywords": [
+                "Flysystem",
+                "adapter",
+                "memory"
+            ],
+            "time": "2016-06-04 03:57:11"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
+                "reference": "adcc9531682cf87dfda21e1fd5d0e7a41d292fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-12-03 22:08:25"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0",
             "source": {
@@ -3700,6 +4195,56 @@
                 "xunit"
             ],
             "time": "2015-10-02 06:51:40"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "sebastian/comparator",

--- a/src/Playbloom/Satisfy/Model/FilePersister.php
+++ b/src/Playbloom/Satisfy/Model/FilePersister.php
@@ -2,16 +2,14 @@
 
 namespace Playbloom\Satisfy\Model;
 
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
-use Exception;
+use League\Flysystem\FilesystemInterface;
 use RuntimeException;
 use InvalidArgumentException;
 use DateTime;
 
 class FilePersister implements PersisterInterface
 {
-    /** @var Filesystem */
+    /** @var FilesystemInterface */
     private $filesystem;
 
     /** @var string */
@@ -21,22 +19,16 @@ class FilePersister implements PersisterInterface
     private $auditlog;
 
     /**
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      * @param string $filename
      * @param string $auditlog
      */
-    public function __construct(Filesystem $filesystem, $filename, $auditlog)
+    public function __construct(FilesystemInterface $filesystem, $filename, $auditlog)
     {
         $this->filesystem = $filesystem;
 
-        $filename = realpath($filename);
-
-        if (!$this->filesystem->exists($filename)) {
+        if (!$this->filesystem->has($filename)) {
             throw new InvalidArgumentException(sprintf('The file "%s" is unavailable', $filename));
-        }
-
-        if (!$this->filesystem->exists($auditlog)) {
-            throw new InvalidArgumentException(sprintf('The audit log directory "%s" is unavailable', $filename));
         }
 
         $this->filename = $filename;
@@ -50,13 +42,12 @@ class FilePersister implements PersisterInterface
      */
     public function load()
     {
-        try {
-            $content = file_get_contents($this->filename);
-        } catch (Exception $exception) {
+        $content = $this->filesystem->read($this->filename);
+
+        if ($content === false) {
             throw new RuntimeException(
                 sprintf('Unable to load the data from "%s"', $this->filename),
-                null,
-                $exception
+                null
             );
         }
 
@@ -71,18 +62,21 @@ class FilePersister implements PersisterInterface
      */
     public function flush($content)
     {
-        try {
-            $this->checkPermissions();
+        $backupFilename = $this->generateBackupFilename();
 
-            $backupFilename = $this->generateBackupFilename();
+        $writeBackup = $this->filesystem->copy($this->filename, $backupFilename);
+        if ($writeBackup === false) {
+            throw new RuntimeException(
+                sprintf('Unable to persist the backup data to "%s"', $backupFilename),
+                null
+            );
+        }
 
-            $this->filesystem->copy($this->filename, $backupFilename);
-            $this->dumpFile($this->filename, $content);
-        } catch (Exception $exception) {
+        $write = $this->filesystem->put($this->filename, $content);
+        if ($write === false) {
             throw new RuntimeException(
                 sprintf('Unable to persist the data to "%s"', $this->filename),
-                null,
-                $exception
+                null
             );
         }
     }
@@ -98,46 +92,5 @@ class FilePersister implements PersisterInterface
         $name = sprintf('%s.json', (new DateTime())->format('Y-m-d_his'));
 
         return $path.'/'.$name;
-    }
-
-    /**
-     * Checks write permission on all needed paths.
-     *
-     * @throws \Symfony\Component\Filesystem\Exception\IOException
-     */
-    protected function checkPermissions()
-    {
-        $paths = array(
-            $this->auditlog,
-            $this->filename
-        );
-
-        foreach ($paths as $path) {
-            if (!is_writeable($path)) {
-                throw new IOException(sprintf('Path "%s" is not writeable.', $path));
-            }
-        }
-    }
-
-    /**
-     * @param string $filename
-     * @param string $content
-     */
-    protected function dumpFile($filename, $content)
-    {
-        $handle = fopen($filename, 'r+');
-        if (!$handle) {
-            throw new IOException(sprintf('Failed to open file "%s" for write', $filename), 0, null, $filename);
-        }
-
-        $locked = flock($handle, LOCK_EX | LOCK_NB);
-        if (!$locked) {
-            throw new IOException(sprintf('Failed to lock file "%s"', $filename), 0, null, $filename);
-        }
-
-        ftruncate($handle, 0);
-        rewind($handle);
-        fwrite($handle, $content);
-        fclose($handle);
     }
 }

--- a/src/Playbloom/Satisfy/Provider/SatisServiceProvider.php
+++ b/src/Playbloom/Satisfy/Provider/SatisServiceProvider.php
@@ -2,10 +2,11 @@
 
 namespace Playbloom\Satisfy\Provider;
 
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
 use Silex\ServiceProviderInterface;
 use Silex\Application;
 use PhpCollection\Map;
-use Symfony\Component\Filesystem\Filesystem;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\Context;
@@ -28,7 +29,8 @@ class SatisServiceProvider implements ServiceProviderInterface
     {
         $app['satis'] = $app->share(function () use ($app) {
 
-            $filesystem = new Filesystem();
+            $filesystemAdapter = new Local($app['satis.rootPath']);
+            $filesystem = new Filesystem($filesystemAdapter);
 
             $serializer = SerializerBuilder::create()
                 ->configureHandlers(function (HandlerRegistry $registry) use ($app) {


### PR DESCRIPTION
Currently Satisfy has a heavy dependency on the underlying file system (UNIX file system). By using [League's Flysystem](https://github.com/thephpleague/flysystem) we can remove that dependency and abstract the file system away.

I embarked on this piece of work because I'm running Satisfy in a containerised environment (Docker) and using a local file system is a problem. With this enhancement, I can now use Amazon's S3 to store the JSON configuration and 'audit log'.