### PR TITLE
#71 include-filename must be a default value

### DIFF
--- a/src/Playbloom/Satisfy/Model/Configuration.php
+++ b/src/Playbloom/Satisfy/Model/Configuration.php
@@ -84,7 +84,7 @@ class Configuration
      * @Type("string")
      * @SerializedName("include-filename")
      */
-    private $includeFilename = '';
+    private $includeFilename = 'include/all$%hash%.json';
 
     /**
      * @var Archive


### PR DESCRIPTION
The default value is [include/all$%hash%.json](https://github.com/composer/satis/blob/master/src/Builder/PackagesBuilder.php#L46)