### PR TITLE
Change .htaccess to compress JSON if modules available

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -28,3 +28,12 @@
     RewriteRule .? %{ENV:BASE}/index.php [QSA,L]
 </IfModule>
 
+#Compress JSON files
+<IfModule mod_headers.c>
+    <IfModule mod_deflate.c>
+        <IfModule mod_filter.c>
+            SetOutputFilter DEFLATE
+            AddOutputFilterByType DEFLATE application/json
+        </IfModule>
+    </IfModule>
+</IfModule>


### PR DESCRIPTION
Save bandwidth and download time when the package file is greater than few MB.
It requires to have the Apache modules deflate, filter, and header to be activated, but doesn't error if they are not available.
Tested successfully with the WebUI and with composer.