### PR TITLE
fix build when satis.json is not in default location

### DIFF
--- a/src/Playbloom/Satisfy/Controller/SatisController.php
+++ b/src/Playbloom/Satisfy/Controller/SatisController.php
@@ -35,7 +35,7 @@ class SatisController extends AbstractProtectedController
         $arguments = $this->container->getParameter('satis_filename');
         $arguments .= ' --skip-errors --no-ansi --no-interaction --verbose';
 
-        $process = new Process($path . '/bin/satis build', $path, $env, $arguments, 600);
+        $process = new Process($path.'/bin/satis build '.$arguments, $path, $env, null, 600);
         $process->start();
 
         $processRead = function () use ($process) {
@@ -46,7 +46,7 @@ class SatisController extends AbstractProtectedController
                 }
                 echo 'data: ', $data, PHP_EOL, PHP_EOL;
             };
-            $print('$ ' . $process->getCommandLine() . ' ' . $process->getInput());
+            $print('$ ' . $process->getCommandLine());
             foreach ($process as $content) {
                 $print($content);
             }


### PR DESCRIPTION
In SatisController, the Process used to invoke the `satis build`command has its arguments passed in the `$input` parameter.
When the processed is invoked, these are not passed properly and they are effectively ignored: the command that is launched is `bin/satis` with no arguments.

![image](https://user-images.githubusercontent.com/576772/43688919-284e7044-98f2-11e8-9577-eaad14ddc8d6.png)


Adding the arguments to the first parameter fixes this.