### PR TITLE
Support installation-source for repository

### DIFF
--- a/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
+++ b/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
@@ -62,7 +62,18 @@ class RepositoryType extends AbstractType
                         'placeholder' => 'Repository url',
                     ],
                 ]
-            );
+            )
+			->add(
+					'installationSource',
+					TextType::class,
+					[
+							'required' => false,
+							'empty_data' => 'dist',
+							'attr' => [
+									'placeholder' => 'Installation source',
+							],
+					]
+			);
     }
 
     /**

--- a/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
+++ b/src/Playbloom/Satisfy/Form/Type/RepositoryType.php
@@ -63,17 +63,18 @@ class RepositoryType extends AbstractType
                     ],
                 ]
             )
-			->add(
-					'installationSource',
-					TextType::class,
-					[
-							'required' => false,
-							'empty_data' => 'dist',
-							'attr' => [
-									'placeholder' => 'Installation source',
-							],
-					]
-			);
+            ->add(
+                'installationSource',
+                ChoiceType::class,
+                [
+                    'required' => false,
+                    'placeholder' => false,
+                    'choices' => [
+                        'dist' => 'dist',
+                        'source' => 'source',
+                    ],
+                ]
+            );
     }
 
     /**

--- a/src/Playbloom/Satisfy/Model/Repository.php
+++ b/src/Playbloom/Satisfy/Model/Repository.php
@@ -2,6 +2,7 @@
 
 namespace Playbloom\Satisfy\Model;
 
+use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
 
 class Repository implements RepositoryInterface
@@ -15,6 +16,13 @@ class Repository implements RepositoryInterface
      * @Type("string")
      */
     private $url;
+
+	/**
+	 * @var string
+	 * @Type("string")
+	 * @SerializedName("installation-source")
+	 */
+	private $installationSource = 'dist';
 
     public function __construct(string $url = '', string $type = 'git')
     {
@@ -75,4 +83,22 @@ class Repository implements RepositoryInterface
 
         return $this;
     }
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getInstallationSource(): string
+	{
+		return $this->installationSource;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setInstallationSource(string $installationSource): RepositoryInterface
+	{
+		$this->installationSource = $installationSource;
+
+		return $this;
+	}
 }

--- a/tests/Playbloom/Satisfy/Controller/RepositoryControllerTest.php
+++ b/tests/Playbloom/Satisfy/Controller/RepositoryControllerTest.php
@@ -75,10 +75,12 @@ class RepositoryControllerTest extends WebTestCase
         $this->assertNotEmpty($config);
 
         $this->assertObjectHasAttribute('repositories', $config);
-        $this->assertEquals([(object)$request], $config->repositories);
+        $this->assertEquals($url, $config->repositories[0]->url);
+        $this->assertEquals('git', $config->repositories[0]->type);
+        $this->assertEquals('dist', $config->repositories[0]->{'installation-source'});
 
         // update repository
-        $params = ['type' => 'github', 'url' => $url2 = 'git@github.com:account/repository.git'];
+        $params = ['type' => 'github', 'url' => $url2 = 'git@github.com:account/repository.git', 'installationSource' => 'source'];
         $crawler = $client->request('GET', '/admin/edit/' . md5($url));
         $form = $crawler->filterXPath('//form');
         $client->submit($form->form(), ['repository' => $params]);
@@ -91,6 +93,7 @@ class RepositoryControllerTest extends WebTestCase
         $config = json_decode($configHandle->getContent());
         $this->assertEquals($url2, $config->repositories[0]->url);
         $this->assertEquals('github', $config->repositories[0]->type);
+        $this->assertEquals('source', $config->repositories[0]->{'installation-source'});
 
         // remove repository
         $crawler = $client->request('GET', '/admin/delete/' . md5($url2));


### PR DESCRIPTION
We are not sure, if there is another way, to support installation-source for repositories.
Ideally, it should always be ``dist``, so we added the form field for the repository to overwrite the value.

Since we had the problem, that source path was used,  even though we had defined ``preferred-install: dist``. 

If there is a better solution to always use the ``dist`` path, then this PR can also be discarded.
