### PR TITLE
Fix escaping slashes and unicode signs in satis.json

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,3 +17,11 @@ framework:
 
 twig:
   form_themes: ['bootstrap_3_layout.html.twig']
+
+jms_serializer:
+  visitors:
+    json:
+      options:
+        - JSON_PRETTY_PRINT
+        - JSON_UNESCAPED_SLASHES
+        - JSON_UNESCAPED_UNICODE

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
         "composer/satis": "dev-master",
         "composer/composer": "^1.7",
         "jms/serializer-bundle": "^2.3",

--- a/src/Playbloom/Satisfy/Serializer/RepositoryCollectionHandler.php
+++ b/src/Playbloom/Satisfy/Serializer/RepositoryCollectionHandler.php
@@ -18,9 +18,6 @@ class RepositoryCollectionHandler
         // We change the base type, and pass through possible parameters.
         $type['name'] = 'array';
         $data = $collection->values();
-        if ($visitor instanceof JsonSerializationVisitor) {
-            $visitor->setOptions(JSON_PRETTY_PRINT);
-        }
 
         return $visitor->visitArray($data, $type, $context);
     }


### PR DESCRIPTION
Hi,

i've used the native configuration of jms_serializer to escape and pretty print the json output for the satis.json.