### PR TITLE
Removing unused composer `require-dev` dependency

### DIFF
--- a/app/MicroKernel.php
+++ b/app/MicroKernel.php
@@ -1,6 +1,5 @@
 <?php
 
-use RDV\SymfonyContainerMocks\DependencyInjection\TestKernelTrait;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -13,7 +12,6 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
 class MicroKernel extends Kernel
 {
     use MicroKernelTrait;
-    use TestKernelTrait;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
When running `composer install --no-dev` for production deployment, found this "unused" trait was not found. Everything else in sastisfy seems to work.