### PR TITLE
Add configuration option for minimum stability level per package

### DIFF
--- a/config/config_test.yml
+++ b/config/config_test.yml
@@ -12,3 +12,5 @@ framework:
 services:
   logger:
     class: Psr\Log\Test\TestLogger
+  twig.exception_listener:
+    class: stdClass

--- a/src/Playbloom/Satisfy/Form/DataTransformer/JsonTextTransformer.php
+++ b/src/Playbloom/Satisfy/Form/DataTransformer/JsonTextTransformer.php
@@ -29,6 +29,9 @@ class JsonTextTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         $value = trim($value);
+        if (empty($value)) {
+            return null;
+        }
         try {
             $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $exception) {

--- a/src/Playbloom/Satisfy/Form/Type/ConfigurationType.php
+++ b/src/Playbloom/Satisfy/Form/Type/ConfigurationType.php
@@ -4,7 +4,10 @@ namespace Playbloom\Satisfy\Form\Type;
 
 use Playbloom\Satisfy\Form\DataTransformer\JsonTextTransformer;
 use Playbloom\Satisfy\Model\Configuration;
+use Playbloom\Satisfy\Model\PackageStability;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -12,6 +15,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class ConfigurationType extends AbstractType
@@ -76,12 +81,23 @@ END
             ])
             ->add('minimumStability', ChoiceType::class, [
                 'required' => false,
-                'choices' => [
-                    'dev' => 'dev',
-                    'alpha' => 'alpha',
-                    'beta' => 'beta',
-                    'RC' => 'RC',
-                    'stable' => 'stable',
+                'choices' => PackageStabilityType::STABILITY_LEVELS,
+                'constraints' => [
+                    new Assert\Choice(['choices' => PackageStabilityType::STABILITY_LEVELS]),
+                ],
+            ])
+            ->add('minimumStabilityPerPackage', CollectionType::class, [
+                'required' => false,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'delete_empty' => true,
+                'entry_type' => PackageStabilityType::class,
+                'prototype' => true,
+                'attr' => [
+                    'class' => 'collection_require',
+                ],
+                'constraints' => [
+                    new Assert\Valid(),
                 ],
             ])
             ->add('includeFilename', TextType::class, [
@@ -124,6 +140,7 @@ END
             ->add('config', TextareaType::class, [
                 'required' => false,
                 'empty_data' => '',
+                'trim' => true,
                 'attr' => [
                     'rel' => 'tooltip',
                     'data-title' => 'a configuration options in json format',

--- a/src/Playbloom/Satisfy/Form/Type/PackageStabilityType.php
+++ b/src/Playbloom/Satisfy/Form/Type/PackageStabilityType.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Playbloom\Satisfy\Form\Type;
+
+use Playbloom\Satisfy\Model\PackageStability;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class PackageStabilityType extends AbstractType
+{
+    public const STABILITY_LEVELS = [
+        'dev' => 'dev',
+        'alpha' => 'alpha',
+        'beta' => 'beta',
+        'RC' => 'RC',
+        'stable' => 'stable',
+    ];
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('package', TextType::class, [
+                'required' => true,
+                'empty_data' => '',
+                'constraints' => [
+                    new Assert\NotBlank(),
+                ],
+                'attr' => [
+                    'placeholder' => 'Package name',
+                ],
+            ])
+            ->add('stability', ChoiceType::class, [
+                'required' => true,
+                'choices' => self::STABILITY_LEVELS,
+                'constraints' => [
+                    new Assert\NotBlank(),
+                    new Assert\Choice(['choices' => self::STABILITY_LEVELS]),
+                ],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => PackageStability::class,
+            'empty_data' => new PackageStability('', ''),
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'PackageStabilityType';
+    }
+}

--- a/src/Playbloom/Satisfy/Model/Configuration.php
+++ b/src/Playbloom/Satisfy/Model/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Playbloom\Satisfy\Model;
 
+use Symfony\Component\Asset\Package;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Webmozart\Assert\Assert;
 
@@ -96,10 +97,16 @@ class Configuration
     private $archive;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("minimum-stability")
      */
     private $minimumStability = 'dev';
+
+    /**
+     * @var PackageStability[]
+     * @SerializedName("minimum-stability-per-package")
+     */
+    private $minimumStabilityPerPackage = [];
 
     /**
      * @var bool
@@ -328,9 +335,30 @@ class Configuration
         return $this->minimumStability;
     }
 
-    public function setMinimumStability(string $minimumStability): void
+    public function setMinimumStability(?string $minimumStability): void
     {
         $this->minimumStability = $minimumStability;
+    }
+
+    /**
+     * @return PackageStability[]
+     */
+    public function getMinimumStabilityPerPackage(): array
+    {
+        return $this->minimumStabilityPerPackage;
+    }
+
+    /**
+     * @param PackageStability[] $minimumStabilityPerPackage
+     */
+    public function setMinimumStabilityPerPackage(array $minimumStabilityPerPackage): void
+    {
+        $this->minimumStabilityPerPackage = $minimumStabilityPerPackage;
+    }
+
+    public function addMinimumStabilityPerPackage(string $package, string $stability): void
+    {
+        $this->minimumStabilityPerPackage[] = new PackageStability($package, $stability);
     }
 
     public function isProviders(): bool

--- a/src/Playbloom/Satisfy/Model/PackageStability.php
+++ b/src/Playbloom/Satisfy/Model/PackageStability.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Playbloom\Satisfy\Model;
+
+class PackageStability
+{
+    /** @var string */
+    private $package;
+
+    /** @var string */
+    private $stability;
+
+    public function __construct(string $package, string $stability)
+    {
+        $this->package = $package;
+        $this->stability = $stability;
+    }
+
+    public function getPackage(): string
+    {
+        return $this->package;
+    }
+
+    public function setPackage(string $package): void
+    {
+        $this->package = $package;
+    }
+
+    public function getStability(): string
+    {
+        return $this->stability;
+    }
+
+    public function setStability(string $stability): void
+    {
+        $this->stability = $stability;
+    }
+}

--- a/src/Playbloom/Satisfy/Persister/ConfigurationNormalizer.php
+++ b/src/Playbloom/Satisfy/Persister/ConfigurationNormalizer.php
@@ -2,8 +2,8 @@
 
 namespace Playbloom\Satisfy\Persister;
 
-use Playbloom\Satisfy\Model\Configuration;
 use Playbloom\Satisfy\Model\PackageConstraint;
+use Playbloom\Satisfy\Model\PackageStability;
 use Playbloom\Satisfy\Model\Repository;
 use Playbloom\Satisfy\Model\RepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -36,6 +36,10 @@ class ConfigurationNormalizer implements NormalizerInterface, DenormalizerInterf
             return $this->denormalizeRepositories($data);
         }
 
+        if ($type === PackageStability::class . '[]') {
+            return $this->denormalizePackageStability($data);
+        }
+
         if ($this->serializer instanceof DenormalizerInterface) {
             return $this->serializer->denormalize($data, $type, $format, $context);
         }
@@ -48,6 +52,7 @@ class ConfigurationNormalizer implements NormalizerInterface, DenormalizerInterf
         switch ($type) {
             case PackageConstraint::class . '[]':
             case RepositoryInterface::class . '[]':
+            case PackageStability::class . '[]':
                 return true;
             default:
         }
@@ -58,16 +63,6 @@ class ConfigurationNormalizer implements NormalizerInterface, DenormalizerInterf
     public function setSerializer(SerializerInterface $serializer)
     {
         $this->serializer = $serializer;
-    }
-
-    private function normalizeRequire($list)
-    {
-        $require = [];
-        foreach ($list as $constraint) {
-            $require[$constraint->getPackage()] = $constraint->getConstraint();
-        }
-
-        return $require;
     }
 
     private function denormalizeRequire($data)
@@ -89,6 +84,16 @@ class ConfigurationNormalizer implements NormalizerInterface, DenormalizerInterf
                 $repository->setInstallationSource($item['installation-source']);
             }
             $list[$repository->getId()] = $repository;
+        }
+
+        return $list;
+    }
+
+    private function denormalizePackageStability($data): array
+    {
+        $list = [];
+        foreach ($data as $package => $stability) {
+            $list[] = new PackageStability($package, $stability);
         }
 
         return $list;

--- a/src/Playbloom/Satisfy/Persister/JsonPersister.php
+++ b/src/Playbloom/Satisfy/Persister/JsonPersister.php
@@ -4,6 +4,7 @@ namespace Playbloom\Satisfy\Persister;
 
 use Playbloom\Satisfy\Model\Configuration;
 use Playbloom\Satisfy\Model\PackageConstraint;
+use Playbloom\Satisfy\Model\PackageStability;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\SerializerAwareTrait;
@@ -48,6 +49,7 @@ class JsonPersister implements PersisterInterface
             AbstractObjectNormalizer::CALLBACKS => [
                 'repositories' => [$this, 'normalizeRepositories'],
                 'require' => [$this, 'normalizeRequire'],
+                'minimumStabilityPerPackage' => [$this, 'normalizePackageStability'],
             ],
             JsonEncode::OPTIONS => JSON_PRETTY_PRINT,
         ]);
@@ -77,5 +79,24 @@ class JsonPersister implements PersisterInterface
         }
 
         return $require;
+    }
+
+    /**
+     * @param PackageStability[] $list
+     *
+     * @return array<string, string>|null
+     */
+    public function normalizePackageStability(array $list): ?array
+    {
+        if (empty($list)) {
+            return null;
+        }
+
+        $data = [];
+        foreach ($list as $item) {
+            $data[$item->getPackage()] = $item->getStability();
+        }
+
+        return $data;
     }
 }

--- a/templates/form/fields.html.twig
+++ b/templates/form/fields.html.twig
@@ -10,3 +10,16 @@
     <div class="col-sm-4">{{ form_widget(form.constraint) }} {{ form_errors(form.constraint) }}</div>
     <div class="col-sm-2 {{ form.parent.vars.id }}-collection-actions"></div>
 {% endblock %}
+
+{% block PackageStabilityType_row %}
+    <div class="clearfix">
+        {{ form_errors(form) }}
+        {{ form_widget(form) }}
+    </div>
+{% endblock %}
+
+{% block PackageStabilityType_widget %}
+    <div class="col-sm-6">{{ form_widget(form.package) }} {{ form_errors(form.package) }}</div>
+    <div class="col-sm-2">{{ form_widget(form.stability) }} {{ form_errors(form.stability) }}</div>
+    <div class="col-sm-2 {{ form.parent.vars.id }}-collection-actions"></div>
+{% endblock %}

--- a/tests/Playbloom/Satisfy/Controller/ConfigurationControllerTest.php
+++ b/tests/Playbloom/Satisfy/Controller/ConfigurationControllerTest.php
@@ -25,4 +25,36 @@ class ConfigurationControllerTest extends WebTestCase
         $response = $client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
+
+    public function testAddStabilityPerPackage(): void
+    {
+        $values = $this->getMinimalValues();
+        $values['configuration']['minimumStabilityPerPackage'] = [
+            [
+                'package' => $package = 'psr/log',
+                'stability' => $stability = 'alpha',
+            ],
+        ];
+
+        $client = self::createClient();
+        $client->request('POST', '/admin/configuration', $values);
+        $response = $client->getResponse();
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $form = $client->getCrawler()->filterXPath('//form')->form();
+        $values = $form->getValues();
+
+        self::assertArrayHasKey('configuration[minimumStabilityPerPackage][0][package]', $values);
+        self::assertArrayHasKey('configuration[minimumStabilityPerPackage][0][stability]', $values);
+        self::assertEquals($package, $values['configuration[minimumStabilityPerPackage][0][package]']);
+        self::assertEquals($stability, $values['configuration[minimumStabilityPerPackage][0][stability]']);
+    }
+
+    protected function getMinimalValues(): array
+    {
+        $values = json_decode(file_get_contents(__DIR__ . '/../../../fixtures/satis-minimal.json'), true);
+
+        return [
+            'configuration' => $values,
+        ];
+    }
 }

--- a/tests/Playbloom/Satisfy/Persister/FilePersisterTest.php
+++ b/tests/Playbloom/Satisfy/Persister/FilePersisterTest.php
@@ -93,6 +93,8 @@ class FilePersisterTest extends KernelTestCase
         $this->assertCount(1, $repositories);
         $this->assertIsString($repositories->key());
         $this->assertInstanceOf(RepositoryInterface::class, $repositories->current());
+        self::assertIsArray($stability = $config->getMinimumStabilityPerPackage());
+        self::assertArrayHasKey(0, $stability);
 
         // append additional repo
         $repositories->append(new Repository('http://localhost'));
@@ -105,6 +107,9 @@ class FilePersisterTest extends KernelTestCase
             $constraint,
             new PackageConstraint('psr/log', '^1.0'),
         ]);
+
+        // add required specific package stability
+        $config->addMinimumStabilityPerPackage('phpunit/phpunit', 'alpha');
 
         $persister->flush($config);
 

--- a/tests/fixtures/satis-full.json
+++ b/tests/fixtures/satis-full.json
@@ -30,6 +30,9 @@
   "providers": true,
   "providers-history-size": 1,
   "minimum-stability": "dev",
+  "minimum-stability-per-package": {
+    "psr/log": "stable"
+  },
   "_comment": "",
   "pretty-print": true
 }


### PR DESCRIPTION
Composer let's configure specific minimum stability level for each package. This PR adds support for satis option `minimum-stability-per-package` [1]

[1] https://github.com/composer/satis/blob/main/res/satis-schema.json#L112

fix #159 