### PR TITLE
Return HTTP status code 500 if the build fails

### DIFF
--- a/src/Playbloom/Satisfy/Webhook/AbstractWebhook.php
+++ b/src/Playbloom/Satisfy/Webhook/AbstractWebhook.php
@@ -44,7 +44,7 @@ abstract class AbstractWebhook
             throw new ServiceUnavailableHttpException();
         }
 
-        return new Response((string)$status);
+        return new Response((string) $status, 0 === $status ? Response::HTTP_OK : Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     public function handle(RepositoryInterface $repository): ?int

--- a/tests/Playbloom/Satisfy/Webhook/AbstractWebhookTest.php
+++ b/tests/Playbloom/Satisfy/Webhook/AbstractWebhookTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Playbloom\Satisfy\Webhook;
+
+use PHPUnit\Framework\TestCase;
+use Playbloom\Satisfy\Model\Repository;
+use Playbloom\Satisfy\Model\RepositoryInterface;
+use Playbloom\Satisfy\Service\Manager;
+use Playbloom\Satisfy\Webhook\AbstractWebhook;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+class AbstractWebhookTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testGetResponseReturnsTheCommandExitCode()
+    {
+        $webhook = $this->createWebhook(0);
+
+        $response = $webhook->getResponse(Request::create('/'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('0', $response->getContent());
+    }
+
+    public function testGetResponseWithErrorsReturns500()
+    {
+        $webhook = $this->createWebhook(1);
+
+        $response = $webhook->getResponse(Request::create('/'));
+
+        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals('1', $response->getContent());
+    }
+
+    public function createWebhook(int $status): AbstractWebhook
+    {
+        $manager = $this->prophesize(Manager::class);
+
+        $webhook = new class($manager->reveal(), new EventDispatcher()) extends AbstractWebhook {
+            public $status;
+
+            public function handle(RepositoryInterface $repository): ?int
+            {
+                return $this->status;
+            }
+
+            protected function validate(Request $request): void
+            {
+            }
+
+            protected function getRepository(Request $request): RepositoryInterface
+            {
+                return new Repository('git@git.example.com', 'git');
+            }
+        };
+
+        $webhook->status = $status;
+
+        return $webhook;
+    }
+}


### PR DESCRIPTION
Hi!

Currently if during the webhook call something bad happens, the HTTP status code will be 200, and the body will contains the command exit code.

This makes hard for the webhook consumers to know if it failed.

With this PR, if the webhhok URL contains a query parameter `fail_on_error`, it will return a 500 response.