### PR TITLE
Retrieve APP_ENV and APP_DEBUG from environment variables

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,20 +4,27 @@ use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__) . '/config/bootstrap.php';
-if ($_SERVER['APP_DEBUG']) {
+
+$appEnv = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
+$appDebug = (bool)($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? true);
+$trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false;
+$trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false;
+
+if ($appDebug) {
     umask(0000);
     Debug::enable();
 }
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+if ($trustedProxies) {
     Request::setTrustedProxies(
         explode(',', $trustedProxies),
         Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST
     );
 }
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
+if ($trustedHosts) {
     Request::setTrustedHosts([$trustedHosts]);
 }
-$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', (bool)($_SERVER['APP_DEBUG'] ?? true));
+
+$kernel = new Kernel($appEnv, $appDebug);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
I tried to set up the satisfy using docker-compose - it worked fine.
But when I tried to change the configuration in https://github.com/ludofleury/satisfy/blob/93f256af7c4b70f6a1aadae8ffd281fc6ce6e628/docker-compose.yml#L10-L11 to prod and 0 accordingly - it was still showing full exception traces.

The investigation shows, that we don't have the APP_ENV and APP_DEBUG variables in the $_SERVER, but we do have them in $_ENV array.

This PR fixes this inability in similar way as it was done for TRUSTED_PROXIES and TRUSTED_HOSTS.
Also, I extracted all 4 variables to separate line declarations for cleaner code.

I believe there no way to cover this change with automated tests.